### PR TITLE
fixup master detail

### DIFF
--- a/app/helpers/data_table_helper.rb
+++ b/app/helpers/data_table_helper.rb
@@ -32,8 +32,7 @@ module DataTableHelper
         masterDetail: {
             enabled: true,
             template: function(container, options) {
-                container.addClass('internal-grid-container').attr('id', options.rowIndex);
-                #{master_detail}(options);
+                #{master_detail}(container, options);
              }
         }
       JS

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.4.2"
+    VERSION = "19.1.4.3"
   end
 end


### PR DESCRIPTION
the masterDetail here doesn't seem to be used in robusta anywhere else I would have altered the relevant master_detail functions to take the extra argument. Each table should implement any specific behaviour and not here in the gem.

just to cater for this - https://codepen.io/anon/pen/oKXyer?&editable=true#anon-login

@WillemOpperman - correct me if I'm wrong but I don't see anything.