### PR TITLE
DX-011 | Fix info modal not showing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.4.9)
+    devextreme-rails (19.1.4.10)
 
 GEM
   remote: https://rubygems.org/

--- a/app/assets/javascripts/data_table_templates.js
+++ b/app/assets/javascripts/data_table_templates.js
@@ -488,7 +488,7 @@ var column_template_exports_portfolio_filters = function(container, options, pop
       .attr("modal-data", function () {
         return $(info).html().toString();
 		  })
-		  .attr("onClick", "showModal(event)")
+		  .attr("onClick", "event.stopPropagation(); showModal(event);")
 		  .appendTo(container);
     }
   }

--- a/app/assets/stylesheets/master_detail.scss
+++ b/app/assets/stylesheets/master_detail.scss
@@ -104,3 +104,7 @@
 .dx-datagrid-rowsview .dx-select-checkboxes-hidden .dx-select-checkbox {
   display: block!important;
 }
+
+#dialog_container .modal {
+  position: fixed !important;
+}

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -27,9 +27,9 @@
   - #        Possible solution is to add a requirement for the gem to have a UserGridLayout store(storage mechanism independent).
   - columns_layout = UserGridLayout.get_user_grid_layout(current_user, self.controller_name, self.action_name, data_table.class.name, data_table.additional_layout_key)
 
-  - highlighted_result = params[:highlighted_result]
-  - highlighted_result_is_text = params[:highlighted_result_is_text] || false
-  #dialog_container
+- highlighted_result = params[:highlighted_result]
+- highlighted_result_is_text = params[:highlighted_result_is_text] || false
+#dialog_container
 
 :javascript
 

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.4.9"
+    VERSION = "19.1.4.10"
   end
 end


### PR DESCRIPTION
There is an issue with the info modal not showing when a user clicks on the pillbox in the export grids.