### PR TITLE
DX-019 | Fix get_value

### DIFF
--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -901,7 +901,7 @@ module Devextreme
         option(:allow_sorting => false)
       end
 
-      def get_value(instance, view_context, text)
+      def get_value(instance, view_context)
         if value_as_lambda?
           @value.call(instance, view_context)
         else


### PR DESCRIPTION
* removed the extra parameter in the get_value method of the ColumnLookup class