### PR TITLE
DX-035 | Retain original sort when sortOption applied

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.1.1)
+    devextreme-rails (19.1.5.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -213,6 +213,8 @@ module Devextreme
 
         sort_params = JSON.parse(sort_params)
 
+        existing_sort = @sorted_and_filtered_query.orders.dup
+
         @sorted_and_filtered_query.orders.clear
 
         sort_params.each do |sorter|
@@ -226,6 +228,8 @@ module Devextreme
           @sorted_and_filtered_query = @sorted_and_filtered_query.order(order_desc ? arel_col.desc : arel_col.asc)
 
         end
+
+        @sorted_and_filtered_query = @sorted_and_filtered_query.order(existing_sort) if existing_sort.present?
       end
 
       def get_arel_column(table, attribute, assoc_attribute)

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.1.1"
+    VERSION = "19.1.5.1.2"
   end
 end


### PR DESCRIPTION
Original Sort Order was lost when grouping was applied. This change allows for the original sort order to be appended onto the new sort order. Therefore, no sorting is lost.