### PR TITLE
DX-039 | BUG | Fix first row red when id is zero

### DIFF
--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -145,7 +145,7 @@
           var row_info_data = rowInfo.data['#{ data_table.base_query.table_name }'];
 
           // Handle rules highlighted_result
-          if (row_info_data.id == #{ highlighted_result_is_text ? "'#{highlighted_result}'" : highlighted_result.to_i }){
+          if (row_info_data.id == #{ highlighted_result_is_text ? "'#{highlighted_result}'" : highlighted_result.to_i } && #{highlighted_result.present?}){
             rowInfo.rowElement.addClass('highlighted_result');
           }
 


### PR DESCRIPTION
Any record that had an ID of 0 would be highlighted in red. This was due to the fact that nil.to_i is 0 and when highlighted_row is nil, but your first row ID is 0, then this causes issues.