### PR TITLE
DX-040 | Fix expander alignment for group and master-detail grids.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.1.6)
+    devextreme-rails (19.1.5.1.7)
 
 GEM
   remote: https://rubygems.org/

--- a/app/assets/stylesheets/dx.common.css
+++ b/app/assets/stylesheets/dx.common.css
@@ -7884,3 +7884,7 @@ input.dx-hidden {
 .dx-deferrendering:not(.dx-pending-rendering) .dx-visible-while-pending-rendering {
   display: none !important;
 }
+
+.dx-datagrid-table .dx-row .dx-command-expand.dx-datagrid-group-space {
+  padding-top: 0px !important;
+}

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.1.6"
+    VERSION = "19.1.5.1.7"
   end
 end


### PR DESCRIPTION
Alignment of the expander arrow/icon was offset from the top too much. I removed the padding.