### PR TITLE
DX-051 | Fix json column string formatting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.1.18)
+    devextreme-rails (19.1.5.1.19)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -1057,6 +1057,14 @@ module Devextreme
       def text(instance, view_context)
         "\"#{super}\""
       end
+
+      def to_csv_text(instance, view_context)
+        # RFC-4180, paragraph "If double-quotes are used to enclose fields,
+        # then a double-quote appearing inside a field must be escaped by preceding it with another double quote."
+        # https://tools.ietf.org/html/rfc4180
+        val = get_value(instance, view_context)
+        val.each { |k, v| val[k] = "\"#{v.strip.gsub('"', '""')}\"" if v.is_a? String }
+      end
     end
 
     class ColumnDecimal < Column

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.1.18"
+    VERSION = "19.1.5.1.19"
   end
 end


### PR DESCRIPTION
Currently, when downloading a grid as CSV, if the grid contains a json field and that json contains a comma in a string value, then the CSV will split that via the comma. This change CSV safely handles string values in json fields.