### PR TITLE
DX-058 | Remove custom loading panel

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.1.25)
+    devextreme-rails (19.1.5.1.26)
 
 GEM
   remote: https://rubygems.org/

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -257,12 +257,4 @@
         }
       }
     });
-
-
-    $(".dx-loadpanel").dxLoadPanel({
-      message: "Loading...",
-      showIndicator: true,
-      position: { of: $('##{container_id} .dx-scrollable-container'), at: 'center', offset: '0 100' },
-      showPane: true
-    });
   });

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.1.25"
+    VERSION = "19.1.5.1.26"
   end
 end


### PR DESCRIPTION
From what I can see this was never needed. It was introduced in this pull request.
[RPLUS-3086](https://jira.confluence.com/browse/RPLUS-3086)
https://github.com/statpro/robusta/pull/2977/files#diff-664b185922776b04edd831d79a43f1e664c7ac4545e5a144e2048ee3586a55a4R159

Removing so the positioning goes back to defaults which is 'center center'