### PR TITLE
DX-060 | Bypass model when querying row count

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.1.33)
+    devextreme-rails (19.1.5.1.34)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -733,13 +733,13 @@ module Devextreme
                         else
                           # Need to run off the base class for STI model.
                           # Activerecord will add the default scope back for STI models
-                          row_count_result = @base_query.model.base_class.unscoped.from(
+                          sql = @base_query.model.base_class.unscoped.from(
                             @base_query.arel_table.create_table_alias(
                               count_query.project(Arel.star.count.as('row_count')
                               ), @base_query.model.base_class.table_name)
-                          ).to_a
+                          ).to_sql
 
-                          row_count_result.first.row_count
+                          @base_query.model.connection.execute(sql).first['row_count']
                         end
                       end
 

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.1.33"
+    VERSION = "19.1.5.1.34"
   end
 end


### PR DESCRIPTION
Currently, there is an issue where, in Rails 5.2, if there is any initialization checks on attributes, or if there is a view model that uses custom sql to query the data, the count query fails, as it is trying to hydrate the model but the attributes that are being checked or validated are not initialized.

Changing the row count to a sql query that doesn't hydrate the model, bypasses any attribute or model checks.

As a note, in Rails 5.1, we were skipping the model hydration and just doing a sql query. So, this change will bring them more in line with each other.