### PR TITLE
DX-061 | Use exec_sql instead of execute

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.1.35)
+    devextreme-rails (19.1.5.1.36)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -739,7 +739,7 @@ module Devextreme
                               ), @base_query.model.base_class.table_name)
                           ).to_sql
 
-                          @base_query.model.connection.execute(sql).first['row_count']
+                          @base_query.model.connection.exec_query(sql).first['row_count']
                         end
                       end
 

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.1.35"
+    VERSION = "19.1.5.1.36"
   end
 end


### PR DESCRIPTION
`@base_query.model.connection.execute(sql).first['row_count']` did not work for a tsql connection. In the tsql connection's case, the execute of the sql qould return 1 regardless of the result.
Changed to use exec_sql.
NOTE: No parameter binding is needed, as Rails >= 5.2 build the sql query with the parameters already built in.