### PR TITLE
DX-062 | Remove support for Rails 5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.1.36)
+    devextreme-rails (19.1.5.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.1.36"
+    VERSION = "19.1.5.2.0"
   end
 end


### PR DESCRIPTION
Seeing that RP and RC are both using rails versions of 5.2 or greater, I am removing the specific checking for Miner Version 1 so that when we upgrade to 6.1, we don't have an issue.