### PR TITLE
DX-063 | Stop using localStorage for sort and filter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (19.1.5.2.0)
+    devextreme-rails (19.1.5.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -54,6 +54,8 @@
 
     var user_grid_layouts_save_layout_path = '#{ disable_state_storing ? '' : user_grid_layouts_save_layout_path}';
 
+    var filter_sort = null;
+
     var dataSource = new DevExpress.data.CustomStore({
       key: '#{ data_table.base_query.table_name }.id',
       load: function(loadOptions) {
@@ -72,8 +74,10 @@
           search_params: search_params
         };
 
-        localStorage.setItem('sortOptions', params.sortOptions);
-        localStorage.setItem('filterOptions', params.filterOptions);
+        filter_sort = {
+          sortOptions: params.sortOptions,
+          filterOptions: params.filterOptions
+        };
 
         $.extend(params, #{ converted_load_options });
 
@@ -178,12 +182,15 @@
           delete gridState.pageSize;
           delete gridState.allowedPageSizes;
           delete gridState.selectedRowKeys;
-          if (localStorage.getItem('sortOptions')) {
-            gridState.sortOptions = JSON.parse(localStorage.getItem('sortOptions'));
-          }
 
-          if (localStorage.getItem('filterOptions')) {
-            gridState.filterOptions = JSON.parse(localStorage.getItem('filterOptions'));
+          if (filter_sort) {
+            if (filter_sort.sortOptions) {
+              gridState.sortOptions = JSON.parse(filter_sort.sortOptions);
+            }
+
+            if (filter_sort.filterOptions) {
+              gridState.filterOptions = JSON.parse(filter_sort.filterOptions);
+            }
           }
 
           var grid = dataGrid.dxDataGrid('instance');

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "19.1.5.2.0"
+    VERSION = "19.1.5.2.1"
   end
 end

--- a/lib/renderers/data_table_csv_renderer.rb
+++ b/lib/renderers/data_table_csv_renderer.rb
@@ -14,8 +14,8 @@ module Devextreme
     options[:columns_layout] = UserGridLayout.get_user_grid_layout(current_user, self.controller_name, self.action_name, model.class.name, model.additional_layout_key)
 
     new_params = params.merge(
-      'filterOptions' => options[:columns_layout]['filterOptions'],
-      'sortOptions' => options[:columns_layout]['sortOptions']
+      'filterOptions' => options.dig(:columns_layout, 'filterOptions'),
+      'sortOptions' => options.dig(:columns_layout, 'sortOptions')
     )
 
     send_data(

--- a/lib/renderers/data_table_xls_renderer.rb
+++ b/lib/renderers/data_table_xls_renderer.rb
@@ -13,8 +13,8 @@ module Devextreme
     options[:columns_layout] = UserGridLayout.get_user_grid_layout(current_user, self.controller_name, self.action_name, model.class.name, model.additional_layout_key)
 
     new_params = params.merge(
-      'filterOptions' => options[:columns_layout]['filterOptions'],
-      'sortOptions' => options[:columns_layout]['sortOptions']
+      'filterOptions' => options.dig(:columns_layout, 'filterOptions'),
+      'sortOptions' => options.dig(:columns_layout, 'sortOptions')
     )
 
     send_data(


### PR DESCRIPTION
localStorage was storing the sorting and filtering for grids, but the information was not being stored uniquely enough for the grids, so the sorting and filtering for one grid was being applied to the next grid being viewed.

Also, the storing of the localStorage is long lived. Meaning that there will be memory bloat.