### PR TITLE
DX-070 | Fix Grid Height

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (22.1.6.pre.0.4)
+    devextreme-rails (22.1.6.pre.0.5)
 
 GEM
   remote: https://rubygems.org/

--- a/app/assets/javascripts/data_table.js
+++ b/app/assets/javascripts/data_table.js
@@ -1,16 +1,11 @@
 /**
- *
+ * DEPRECATED
  * @param dataGrid
  * @param height E.g 50%, 50vh, 500px
  * @param width E.g 60%, 60vw, 600px
  * @constructor
  */
  window.ItemResize = function(dataGrid, height, width) {
-  // Remove any window events triggering this if the grid has been removed from the dom.
-  if (dataGrid.length < 1) {
-    $(window).off('load resize', window["_resize_" + dataGrid.selector.replace('#', '')]);
-    return;
-  }
   if (!(height || width)){
     var screenHeight = $('.navbar-fixed-bottom').offset().top - $('#' + dataGrid.attr('id') + '-holder').offset().top;
     var footerHeight = $('footer').height();

--- a/app/assets/javascripts/master_detail.js
+++ b/app/assets/javascripts/master_detail.js
@@ -14,23 +14,12 @@ $('.grow').one('webkitTransitionEnd otransitionend oTransitionEnd msTransitionEn
   $thisGridL1.css('overflow', 'none');
 });
 
-function unregister_resize($grid) {
-  if (typeof($grid) != 'undefined') {
-    var fn_resize_grid = window["_resize_" + $grid.attr('id')]
-    if (typeof (fn_resize_grid) != 'undefined') {
-      $(window).off('resize', fn_resize_grid);
-    }
-  }
-}
-
 function show_level_1(data_to_show) {
   $('#selected_container_id').val('level_1_grid');
   $('#is_master_detail').val(true);
   $level1.addClass('span12 grow dx-back-hidden').html(data_to_show).removeClass('hidden');
   $level2.removeClass('span3 span6').addClass('hidden').animateCss('fadeInRight');
   $level3.removeClass('span6').addClass('hidden').animateCss('fadeInLeft');
-  unregister_resize($thisGridL2);
-  unregister_resize($thisGridL3);
   remove_level_back('level_1');
   remove_level_back('level_2');
 }
@@ -48,7 +37,6 @@ window.show_level_2 = function(data_to_show) {
   if ($thisGridL2.length > 0) {
     reset_grid($thisGridL2, 'level_2');
   }
-  unregister_resize($thisGridL3);
   remove_level_back('level_2');
 }
 

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -27,12 +27,6 @@
 #dialog_container
 
 :javascript
-
-  function _resize_#{container_id}() {
-    ItemResize($("##{ container_id }"), "#{height}", "#{width}");
-  }
-  $(window).on('load resize', _resize_#{container_id});
-
   $(function() {
     var dataGrid = $("##{ container_id }");
 
@@ -143,14 +137,10 @@
           loadpanel.show();
         }
         activateJSPlugins();
-        // This sets the height of the grid to allow for the grid to scroll correctly when in infinite scroll mode.
-        // Note: Should rather be replaced with css height calculation:
-        //   .dxDataGrid-container {
-        //     height: calc(100vh - $menu-height - $toolbar-height - $footer-height);
-        //   }
-        // or a better solution would be to change to use flex layouts
-        _resize_#{container_id}();
       }#{ functions },
+      onInitialized(e){
+        e.component.option("scrolling.prerenderedRowCount",10);
+      },
       onRowPrepared: function (rowInfo) {
         if (rowInfo.data && rowInfo.rowType != 'group' && rowInfo.data['#{ data_table.base_query.table_name }'] ) {
           var row_info_data = rowInfo.data['#{ data_table.base_query.table_name }'];
@@ -250,7 +240,7 @@
           });
         }
       },
-
+      height: #{height || "`calc(100vh - ${$('##{container_id}-holder').parent().parent().offset().top + ($('footer').height() * 2)}px)`"},
       repaintChangesOnly: true,
       onCellPrepared: function(e) {
         if(e.rowType === "data") {

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "22.1.6-0.4"
+    VERSION = "22.1.6-0.5"
   end
 end


### PR DESCRIPTION
The height function of the datagrid has been deprecated, and due to this, we removed the height function. The problem is that we implemented the height function to get around an issue that we were experiencing with virtual/infinite scolling and fixed columns. When data took too long to load, the grid would misalign, and would not sort correclty. This was mainly due to the fact that DevExpress had changed the way that it handled virtual/infinite scrolling.

With the hack that we used, we were experiencing strange behaviour in v19, but that behaviour got worse with later versions, when DevExpress replaced the scrolling engine all together. https://supportcenter.devexpress.com/ticket/details/t1034020/datagrid-treelist-virtual-scrolling-engine-enhancement

I have tried removing the height function, setting the scrolling to legacyMode, forcing height refreshes, and changing event handlers. All of which failed to achieve the correct results.

I eventually ran across: https://supportcenter.devexpress.com/ticket/details/t1046212/datagrid-virtual-scrolling-gray-boxes-are-shown-in-fixed-columns-when-the-grid-is

After setting the prerenderedRowCount in the onInitialized event handler, and setting the height to a css value, it worked.

We should still monitor this, but it seems to have fixed all of the grid issues we were having.