### PR TITLE
SCNINE-2715 | RC: Pending changes-The checkbox should remain checked when the magnifying glass is clicked.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 /.idea/
+/node_modules
 
 # rspec failure tracking
 .rspec_status

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (22.1.6.pre.0.23)
+    devextreme-rails (22.1.6.pre.0.24)
 
 GEM
   remote: https://rubygems.org/

--- a/app/assets/javascripts/master_detail.js
+++ b/app/assets/javascripts/master_detail.js
@@ -92,13 +92,14 @@ function clickBack(btn, level) {
 function reset_grid(selector, level, factory_reset = false){
   var $grid = $(selector);
   var dataGrid;
+  var apply_default_state_on_reset = $grid.data("internal_master_detail-apply_default_state_on_reset") ?? true;
 
   try {
     if ($grid.data("compact-view") && ($grid.data("compact-view")[level] || []).length > 0) {
       $.each($grid.data("compact-view")[level], function (i, item) {
         $grid.dxDataGrid('columnOption', item.name, item.property, item.value);
       });
-    } else if (factory_reset) {
+    } else if (factory_reset && apply_default_state_on_reset) {
       if ($grid.data("default-state-json") !== undefined) {
         $grid.dxDataGrid('instance').state($grid.data("default-state-json"));
       } else {

--- a/app/assets/javascripts/master_detail.js
+++ b/app/assets/javascripts/master_detail.js
@@ -93,6 +93,7 @@ function reset_grid(selector, level, factory_reset = false){
   var $grid = $(selector);
   var dataGrid;
   var apply_default_state_on_reset = $grid.data("internal_master_detail-apply_default_state_on_reset") ?? true;
+  var disable_repaint = $grid.data("internal_master_detail-disable_repaint") ?? false;
 
   try {
     if ($grid.data("compact-view") && ($grid.data("compact-view")[level] || []).length > 0) {
@@ -113,6 +114,8 @@ function reset_grid(selector, level, factory_reset = false){
     // Catches the instance where the compact view is not defined in a master detail (but its indeterminable)
   }
   finally {
+    if (disable_repaint) return;
+
     window.setTimeout(function () {
       // If someone is clicking fast on different rows, the grid may not be on the dom anymore.
       // We don't want to repaint the grid if it isn't there. Plus, it will fail if it isn't there.

--- a/app/assets/javascripts/master_detail.js
+++ b/app/assets/javascripts/master_detail.js
@@ -92,7 +92,23 @@ function clickBack(btn, level) {
 function reset_grid(selector, level, factory_reset = false){
   var $grid = $(selector);
   var dataGrid;
+
+  /**
+   * This setting is used to bypass setting the grid back to the default state when reset_grid is called without a compact view.
+   * This prevents the grid from reloading/refreshing and making additional calls to the server when it's not necessary.
+   * Note: this is only applicable when we do not have a compact view defined for the grid as the compact view columns
+   *       will no longer resize themselves nicely.
+   **/
   var apply_default_state_on_reset = $grid.data("internal_master_detail-apply_default_state_on_reset") ?? true;
+
+  /**
+   * This setting is to disable repainting of the grid and updating dimensions when reset_grid is called.
+   * This produces a smoother experience as the columns will no longer resize themselves when switching between levels.
+   * Repaint should only be disabled if there is no need to resize columns to fit them on the left of the page when the
+   * second grid is shown.
+   * Note: this is only applicable when we do not have a compact view defined for the grid as the compact view columns
+   *       will no longer resize themselves nicely.
+   **/
   var disable_repaint = $grid.data("internal_master_detail-disable_repaint") ?? false;
 
   try {

--- a/app/assets/javascripts/master_detail.js
+++ b/app/assets/javascripts/master_detail.js
@@ -89,48 +89,39 @@ function clickBack(btn, level) {
   });
 }
 
-function reset_grid(selector, level){
+function reset_grid(selector, level, factory_reset = false){
   var $grid = $(selector);
   var dataGrid;
 
   try {
-    if($grid.data("compact-view") && ($grid.data("compact-view")[level] || []).length > 0) {
-      $.each($grid.data("compact-view")[level], function(i, item) {
+    if ($grid.data("compact-view") && ($grid.data("compact-view")[level] || []).length > 0) {
+      $.each($grid.data("compact-view")[level], function (i, item) {
         $grid.dxDataGrid('columnOption', item.name, item.property, item.value);
       });
+    } else if (factory_reset) {
+      if ($grid.data("default-state-json") !== undefined) {
+        $grid.dxDataGrid('instance').state($grid.data("default-state-json"));
+      } else {
+        $grid.dxDataGrid({
+          columns: $grid.data("default-json")
+        });
+      }
     }
   }
   catch(e) {
     // Catches the instance where the compact view is not defined in a master detail (but its indeterminable)
   }
   finally {
-    window.setTimeout(function(){
+    window.setTimeout(function () {
       // If someone is clicking fast on different rows, the grid may not be on the dom anymore.
       // We don't want to repaint the grid if it isn't there. Plus, it will fail if it isn't there.
       if ($(selector).length > 0) {
         dataGrid = $grid.dxDataGrid('instance');
-        dataGrid.updateDimensions();
         dataGrid.repaint();
+        dataGrid.updateDimensions();
       }
     }, 1000);
   }
-}
-
-function factory_reset_grid($grid){
-  if ($grid.data("default-state-json") !== undefined) {
-    $grid.dxDataGrid('instance').state($grid.data("default-state-json"));
-  } else {
-    $grid.dxDataGrid({
-      columns: $grid.data("default-json")
-    });
-  }
-
-  var dataGrid = $grid.dxDataGrid('instance');
-  dataGrid.clearSelection();
-  window.setTimeout(function(){
-    dataGrid.updateDimensions();
-    dataGrid.repaint();
-  }, 1000);
 }
 
 window.initMasterDetail = function() {
@@ -148,13 +139,7 @@ window.initMasterDetail = function() {
   clickBack('.btn-return-l2', show_level_2);
 
   $('body').on('click', '.btn-return-l1', function () {
-    if ($thisGridL1.data("compact-view") && ($thisGridL1.data("compact-view")['level_1'] || []).length > 0) {
-      reset_grid('#level_1_grid', 'level_1');
-      $thisGridL1.dxDataGrid('instance').clearSelection();
-    } else {
-      //keep original functionality if there is no level 1 setup in the datatable.
-      factory_reset_grid($thisGridL1)
-    }
+    reset_grid('#level_1_grid', 'level_1', true)
   });
 
   this.showErrorDialog = function() {

--- a/app/assets/stylesheets/master_detail.scss
+++ b/app/assets/stylesheets/master_detail.scss
@@ -81,12 +81,12 @@
   }
 
   .grow {
-    -webkit-transition: width .7s ease-in-out;
-    -moz-transition: all .7s ease-in-out;
-    -ms-transition: all .7s ease-in-out;
-    -o-transition: all .7s ease-in-out;
-    -webkit-transition: all .7s ease-in-out;
-    transition: all .7s;
+    -webkit-transition: width .5s ease-in-out;
+    -moz-transition: all .5s ease-in-out;
+    -ms-transition: all .5s ease-in-out;
+    -o-transition: all .5s ease-in-out;
+    -webkit-transition: all .5s ease-in-out;
+    transition: all .5s;
   }
 
 }

--- a/app/helpers/data_table_helper.rb
+++ b/app/helpers/data_table_helper.rb
@@ -101,6 +101,8 @@ module DataTableHelper
     compact_view = data_table.options.delete(:compact_view)
     compact_view_json = compact_view ? compact_view.to_json : [].to_json
 
+    internal_master_detail_options = data_table.options.delete(:internal_master_detail) || {}
+
     custom_summary_functions = []
     summaries_json = data_table.summaries.map do |summary|
       sum_data = []
@@ -155,7 +157,8 @@ module DataTableHelper
         :requireTotalRowCountIndicator => require_total_row_count_indicator,
         :options => options,
         :data_options_json => data_options_json,
-        :state_storing_json => state_storing_json
+        :state_storing_json => state_storing_json,
+        :internal_master_detail_options => internal_master_detail_options
       }
     )
   end

--- a/app/helpers/data_table_helper.rb
+++ b/app/helpers/data_table_helper.rb
@@ -12,6 +12,7 @@ module DataTableHelper
     height = options.delete(:height)
     width = options.delete(:width)
 
+    preserve_selected_rows = data_table.options.delete(:preserve_selected_rows) || false
     selection_changed = options.delete(:selection_changed)
     row_expanding = options.delete(:row_expanding)
     master_detail = options.delete(:master_detail)
@@ -45,16 +46,12 @@ module DataTableHelper
       ,
        onSelectionChanged: function (selecteditems) {
          if (selecteditems.selectedRowKeys.length <= 0) return;
-    JS
+         
+         #{selection_changed.present? ? "#{selection_changed}(selecteditems)" : ''}
 
-    if selection_changed
-      functions += <<-JS
-        #{selection_changed}(selecteditems);
-      JS
-    end
-
-    functions += <<-JS
-      }
+         if (#{preserve_selected_rows})
+           selectedRowKeys = selecteditems.selectedRowKeys;
+       }
     JS
 
     if row_expanding
@@ -158,7 +155,8 @@ module DataTableHelper
         :options => options,
         :data_options_json => data_options_json,
         :state_storing_json => state_storing_json,
-        :internal_master_detail_options => internal_master_detail_options
+        :internal_master_detail_options => internal_master_detail_options,
+        :preserve_selected_rows => preserve_selected_rows
       }
     )
   end

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -128,6 +128,7 @@
       onShown: function(e){ e.component.hide(); }
     });
 
+    var selectedRowKeys = [];
     var gridDataSourceConfiguration_#{ container_id } = { store: dataSource_#{ container_id } };
     dataGrid_#{ container_id }.dxDataGrid({
       dataSource: gridDataSourceConfiguration_#{ container_id },
@@ -152,6 +153,11 @@
 
           loadpanel.show();
         }
+
+        if (#{preserve_selected_rows}) {
+          dataGrid_#{ container_id }.dxDataGrid('option', 'selectedRowKeys', selectedRowKeys);
+        }
+
         activateJSPlugins();
       }#{ functions },
       onShow: function(e) {

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -45,6 +45,8 @@
     let compact_view_json = #{compact_view_json};
     dataGrid_#{ container_id }.data("compact-view", compact_view_json);
 
+    dataGrid_#{ container_id }.data("internal_master_detail-apply_default_state_on_reset", #{internal_master_detail_options.fetch(:apply_default_state_on_reset, true)});
+
     // default-json is used as a fallback layout if there is no level 1 layout set on master-detail.
     let columns_json = [#{columns_json}];
     dataGrid_#{ container_id }.data("default-json", columns_json);

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -46,6 +46,7 @@
     dataGrid_#{ container_id }.data("compact-view", compact_view_json);
 
     dataGrid_#{ container_id }.data("internal_master_detail-apply_default_state_on_reset", #{internal_master_detail_options.fetch(:apply_default_state_on_reset, true)});
+    dataGrid_#{ container_id }.data("internal_master_detail-disable_repaint", #{internal_master_detail_options.fetch(:disable_repaint, false)});
 
     // default-json is used as a fallback layout if there is no level 1 layout set on master-detail.
     let columns_json = [#{columns_json}];

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -124,6 +124,9 @@ module Devextreme
             :visible => true,
             :csv_visible => true,
             :xls_visible => true
+          },
+          :internal_master_detail => {
+            :apply_default_state_on_reset => true
           }
 
         }

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -129,6 +129,7 @@ module Devextreme
             :apply_default_state_on_reset => true,
             :disable_repaint => false
           },
+          # This setting preserves the selected rows when the grid is reset such as when the user navigates between level 1 and level 2 grids.
           :preserve_selected_rows => false
 
         }

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -128,7 +128,8 @@ module Devextreme
           :internal_master_detail => {
             :apply_default_state_on_reset => true,
             :disable_repaint => false
-          }
+          },
+          :preserve_selected_rows => false
 
         }
 

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -126,7 +126,8 @@ module Devextreme
             :xls_visible => true
           },
           :internal_master_detail => {
-            :apply_default_state_on_reset => true
+            :apply_default_state_on_reset => true,
+            :disable_repaint => false
           }
 
         }

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "22.1.6-0.23"
+    VERSION = "22.1.6-0.24"
   end
 end


### PR DESCRIPTION
[SCNINE-2715](https://confluencetechnologies.atlassian.net/browse/SCNINE-2715)

There is a bug on the data tables when selecting rows on a level 1 grid and opening/closing a level 2 grid which causes the row selection to be cleared.

This PR introduces 3 new data grid options to fix this problem.

**preserve_selected_rows:**
This will save the selected rows before they are cleared and reset them back once the grid has been repainted/reloaded.

**apply_default_state_on_reset:**
This will prevent the state of the grid from being set to default-json/default-state-json which was causing the grid selection to be cleared. This prevents the grid from being refreshed and and an additional call being made to fetch the data.

**disable_repaint:**
This will prevent updating dimensions and repaint from being called in the setTimeout. This will prevent columns from being resized to fit on the left of the page when navigating showing/hiding a level 2 grid so therefore should only be used when we don't care too much about which columns the level 1 grid displays while the level 2 grid is open.

**Note:** when repaint is disabled with a compact view, the compact view columns subset will not be displayed correctly as the columns won't be resized and the user may need to scroll left/right to view all the visible compact columns.


[SCNINE-2715]: https://confluencetechnologies.atlassian.net/browse/SCNINE-2715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ