### PR TITLE
SCNINE-2830 | Timeseries displaying zero values should not be shaded yellow at Firm level

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (22.1.6.pre.0.24)
+    devextreme-rails (22.1.6.pre.0.25)
 
 GEM
   remote: https://rubygems.org/

--- a/app/views/data_tables/_data_table.html.haml
+++ b/app/views/data_tables/_data_table.html.haml
@@ -270,7 +270,7 @@
           if(data_cell_css_class != undefined) {
             e.cellElement.addClass(data_cell_css_class)
 
-            if (!e.data['#{data_table.base_query.table_name}'][e.column.dataFieldWithoutTable] && data_cell_css_class != "") {
+            if (e.data['#{data_table.base_query.table_name}'][e.column.dataFieldWithoutTable] === undefined && data_cell_css_class != "") {
               var color = $(e.cellElement).css('background-color');
               var new_cell_background_color_class = (color == 'transparent' ? "dx-cell-error-odd" : "dx-cell-error-even");
 

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "22.1.6-0.24"
+    VERSION = "22.1.6-0.25"
   end
 end


### PR DESCRIPTION
[SCNINE-2830](https://confluencetechnologies.atlassian.net/browse/SCNINE-2830)

When adding the css error class to shade the cell with the error shading, we were checking if the value was !falsy and contained a class. This meant that 0 would pass this check and all 0 rows would be shaded as errors.

**Fix**: explicitly check if the value is undefined rather than !falsy.