### PR TITLE
fix: translation defaults cause csv to fail

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    devextreme-rails (24.2.3.pre.0.3)
+    devextreme-rails (24.2.3.pre.0.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -1099,7 +1099,9 @@ module Devextreme
         unless @caption.is_a?(String)
           translation_params = @options.delete(:translation_params) || {}
           @caption = @name.first if @name.is_a? Array
-          @caption = I18n.t(:"#{@t_scope}.#{@caption}", **{ scope: :data_tables, default: [:"common.#{@caption}", @caption.to_s.titleize] }.merge(translation_params))
+          default_caption = I18n.translate(@caption, **{:scope => [:data_tables, :common] }, :default => nil)
+          default_caption ||= :none
+          @caption = I18n.translate(@caption, **{:scope => [:data_tables, @t_scope], :default => default_caption}.merge(translation_params))
         end
         @params = {}
         @params[:link_to] = @options.delete(:link_to)

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -1099,9 +1099,9 @@ module Devextreme
         unless @caption.is_a?(String)
           translation_params = @options.delete(:translation_params) || {}
           @caption = @name.first if @name.is_a? Array
-          default_caption = I18n.translate(@caption, **{:scope => [:data_tables, :common] }, :default => nil)
+          default_caption = I18n.translate(@caption, **{ :scope => [:data_tables, :common] }, :default => nil)
           default_caption ||= :none
-          @caption = I18n.translate(@caption, **{:scope => [:data_tables, @t_scope], :default => default_caption}.merge(translation_params))
+          @caption = I18n.translate(@caption, **{ :scope => [:data_tables, @t_scope], :default => default_caption }.merge(translation_params))
         end
         @params = {}
         @params[:link_to] = @options.delete(:link_to)

--- a/lib/data_table.rb
+++ b/lib/data_table.rb
@@ -1099,7 +1099,7 @@ module Devextreme
         unless @caption.is_a?(String)
           translation_params = @options.delete(:translation_params) || {}
           @caption = @name.first if @name.is_a? Array
-          @caption = I18n.t(:"#{@t_scope}.#{@caption}", **{ scope: :data_tables, default: [:"common.#{@caption}"] }.merge(translation_params))
+          @caption = I18n.t(:"#{@t_scope}.#{@caption}", **{ scope: :data_tables, default: [:"common.#{@caption}", @caption.to_s.titleize] }.merge(translation_params))
         end
         @params = {}
         @params[:link_to] = @options.delete(:link_to)

--- a/lib/devextreme/rails/version.rb
+++ b/lib/devextreme/rails/version.rb
@@ -2,6 +2,6 @@ module Devextreme
   module Rails
     # use the same version number as the dx.webappjs
     # with the extra minor version to represent any version changes to this wrapper gem but not the underlying devextreme js.
-    VERSION = "24.2.3-0.3"
+    VERSION = "24.2.3-0.4"
   end
 end


### PR DESCRIPTION
Currently, when there are no translations for a field of a datatable, and there is no common translation for that field, then creating a csv for the datatable will not work due to i18n listing the missing translations(with new lines).

The pull request defaults the text for the column header to the "Titleized" version of the field name.